### PR TITLE
Improve node setup in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,31 +7,15 @@ on:
     branches: [ master ]
 
 jobs:
-  read-node-version:
-    name: Read Node.js version
-    outputs:
-      node-version: ${{ steps.node-version.outputs.NODE_VERSION }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Read .nvmrc
-        id: node-version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs:
-      - read-node-version
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ needs.read-node-version.outputs.node-version }}
+      - name: Setip Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ needs.read-node-version.outputs.node-version }}
+          node-version-file: .nvmrc
       - uses: actions/cache@v2
         with:
           path: ~/.npm


### PR DESCRIPTION
This should improve build performance by removing one job to rely on
`actions/setup-node@v2` mechanism to read a `.nvmrc` file.

See: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file